### PR TITLE
Update crosstab to support more types of input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Pytest/Connection String Storage
+envfile.txt
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+matrix:
+  include:
+    - addons:
+        postgresql: 9.2
+    - addons:
+        postgresql: 9.3
+    - addons:
+        postgresql: 9.4
+    - addons:
+        postgresql: 9.5
+    - addons:
+        postgresql: 9.6
+services:
+  - postgresql
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: "pip install -r requirements.txt"
+script: pytest
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,12 @@
 language: python
-matrix:
-  include:
-    - addons:
-        postgresql: 9.2
-    - addons:
-        postgresql: 9.3
-    - addons:
-        postgresql: 9.4
-    - addons:
-        postgresql: 9.5
-    - addons:
-        postgresql: 9.6
 services:
   - postgresql
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
 install: "pip install -r requirements.txt"
 script: pytest
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -c 'CREATE EXTENSION tablefunc' -d travis_ci_test -U postgres

--- a/crosstab.py
+++ b/crosstab.py
@@ -11,6 +11,10 @@ class crosstab(FromClause):
         self.columns = return_def if isinstance(return_def, (list, tuple)) \
             else return_def.columns
         self.categories = categories
+        if hasattr(return_def, 'name'):
+            self.name = return_def.name
+        else:
+            self.name = None
 
         if isinstance(self.stmt, Query):
             self.stmt = self.stmt.selectable

--- a/crosstab.py
+++ b/crosstab.py
@@ -1,12 +1,21 @@
 from sqlalchemy.sql import FromClause, column, ColumnElement
+from sqlalchemy.orm import Query
 from sqlalchemy.ext.compiler import compiles
 
 class crosstab(FromClause):
     def __init__(self, stmt, return_def, categories=None, auto_order=True):
+        if not (isinstance(return_def, (list, tuple))
+                or return_def.is_selectable):
+            raise TypeError('return_def must be a selectable or tuple/list')
         self.stmt = stmt
-        self.return_name = return_def.name
-        self.columns = return_def.columns
+        self.columns = return_def if isinstance(return_def, (list, tuple)) \
+            else return_def.columns
         self.categories = categories
+
+        if isinstance(self.stmt, Query):
+            self.stmt = self.stmt.selectable
+        if isinstance(self.categories, Query):
+            self.categories = self.categories.selectable
 
         #Don't rely on the user to order their stuff
         if auto_order:
@@ -20,22 +29,20 @@ class crosstab(FromClause):
             for name, type_ in self.names
         )
 
-@compiles(crosstab)
+@compiles(crosstab, 'postgresql')
 def visit_element(element, compiler, **kw):
     if element.categories is not None:
-        return """crosstab($$%s$$, $$%s$$) AS %s(%s)""" % (
+        return """crosstab($$%s$$, $$%s$$) AS (%s)""" % (
             compiler.visit_select(element.stmt),
             compiler.visit_select(element.categories),
-            element.return_name,
             ", ".join(
                 "\"%s\" %s" % (c.name, compiler.visit_typeclause(c))
                 for c in element.c
                 )
             )
     else:
-        return """crosstab($$%s$$) AS %s(%s)""" % (
+        return """crosstab($$%s$$) AS (%s)""" % (
             compiler.visit_select(element.stmt),
-            element.return_name,
             ", ".join(
                 "%s %s" % (c.name, compiler.visit_typeclause(c))
                 for c in element.c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
---index-url https://pypi.python.org/simple/
-
--e .
+sqlalchemy>=1.0
+pytest>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sqlalchemy>=1.0
 pytest>=3.0
+psycopg2

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'sqlalchemy',
-        'pytest'
+        'pytest',
+        'psycopg2'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'sqlalchemy',
+        'pytest'
     ],
 )

--- a/test_crosstab.py
+++ b/test_crosstab.py
@@ -1,0 +1,422 @@
+from __future__ import print_function
+import os
+import pytest
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.exc import CompileError
+from sqlalchemy import Table, Column, Text, Integer, MetaData, distinct, select
+from sqlalchemy import create_engine, func
+from crosstab import crosstab
+
+
+# Yes, this is a lot of fixtures. I think the modularity is useful.
+
+@pytest.fixture(scope="module", params=('envfile.txt',))
+def pgengine(request):
+    """Create a sqlalchemy engine for a PostgreSQL DB."""
+    envFile = request.param
+    if envFile != '' and envFile is not None:
+        with open(envFile) as envVars:
+            for line in envVars:
+                var, val = line.split('=', 1)
+                var = var.strip()
+                val = val.strip()
+                os.environ[var] = val
+    dbConnectionString = os.environ['DBCONNECTION']
+    return create_engine(dbConnectionString, echo=True)
+
+
+@pytest.fixture(scope="module")
+def sqliteEngine():
+    """Create a sqlalchemy engine for a memory-only SQLite instance."""
+    return create_engine('sqlite:///:memory:', echo=True)
+
+
+@pytest.fixture(scope="function")
+def pgmetadata(pgengine):
+    """Creates a metadata object for the engine for SQLA Core Tests."""
+    meta = MetaData(bind=pgengine)
+    yield meta
+    meta.drop_all()
+
+
+@pytest.fixture(scope="function")
+def tableraw(pgmetadata):
+    #Set up the sample source data
+    raw = Table('raw', pgmetadata,
+                Column('country', Text),
+                Column('year', Integer),
+                Column('quantity', Integer),
+                Column('unrelated_field', Text))
+    data = [
+            ('India', 2009, 100, "foo"),
+            ('India', 2010, 150, "foo"),
+            ('India', 2011, 200, "foo"),
+            ('Czechoslovakia', 2008, 200, "foo"),
+            ('Czechoslovakia', 2010, 400, "foo")
+            ]
+    raw.create()
+    for line in data:
+        raw.insert().values(line).execute()
+    yield raw
+    raw.drop()
+
+
+# ---------- ORM Fixtures -------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def OrmBase():
+    return declarative_base()
+
+
+@pytest.fixture(scope="module")
+def ormCensus(OrmBase):
+    class OrmCensus(OrmBase):
+        __tablename__ = 'ormcensus'
+        id = Column(Integer, primary_key=True)
+        country = Column(Text)
+        year = Column(Integer)
+        quantity = Column(Integer)
+        unrelated_field = Column(Text)
+
+    return OrmCensus
+
+
+@pytest.fixture(scope="module")
+def pgsessionclass(pgengine, OrmBase, ormCensus):
+    """Creates a Session class, which can then generate sessions."""
+    OrmBase.metadata.create_all(pgengine)
+    return sessionmaker(bind=pgengine)
+
+
+@pytest.fixture(scope="function")
+def pgsession(pgsessionclass):
+    """Create an ORM Session for PostgreSQL."""
+    sess = pgsessionclass()
+    yield sess
+    sess.rollback()
+
+
+@pytest.fixture(scope="function")
+def ormCensusData(ormCensus, pgsession):
+    pgsession.add_all([
+        ormCensus(country='India', year=2009, quantity=100, unrelated_field='foo'),
+        ormCensus(country='India', year=2010, quantity=150, unrelated_field='foo'),
+        ormCensus(country='India', year=2011, quantity=200, unrelated_field='foo'),
+        ormCensus(country='Czechoslovakia', year=2008, quantity=200, unrelated_field='foo'),
+        ormCensus(country='Czechoslovakia', year=2010, quantity=400, unrelated_field='foo')
+    ])
+
+
+# -------------------------------------------------------------------------
+# And now for the tests.
+
+
+def test_coreReturnAll(pgengine, pgmetadata, tableraw):
+    """Test the simple case of crosstabing all of the data in the table."""
+    raw = tableraw
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.country,
+                raw.c.year,
+                raw.c.quantity])
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = Table('ct', pgmetadata,
+                      Column('country', Text),
+                      Column('y1', Integer),
+                      Column('y2', Integer),
+                      Column('y3', Integer),
+                      Column('y4', Integer),
+                      )
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    assert [tuple(x) for x in pgengine.execute(q)] == [
+        ('Czechoslovakia', 200, None, 400, None),
+        ('India', None, 100, 150, 200)
+        ]
+
+def test_coreReturnSome(pgengine, pgmetadata, tableraw):
+    """Test the case of crossstabing a query with a where clause."""
+    raw = tableraw
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.country,
+                raw.c.year,
+                raw.c.quantity]).where(raw.c.country == 'India')
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = Table('ct', pgmetadata,
+                      Column('country', Text),
+                      Column('y1', Integer),
+                      Column('y2', Integer),
+                      Column('y3', Integer),
+                      Column('y4', Integer),
+                      )
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    assert [tuple(x) for x in pgengine.execute(q)] == [
+        ('India', None, 100, 150, 200)
+        ]
+
+
+def test_coreAggregation(pgengine, pgmetadata, tableraw):
+    """Test the case of crossstabing with a sum() and a where clause."""
+    raw = tableraw
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.unrelated_field,
+                raw.c.year,
+                func.sum(raw.c.quantity).label('quantity')]
+           ).where(
+               raw.c.unrelated_field == 'foo'
+           ).group_by(
+               raw.c.unrelated_field,
+               raw.c.year
+           )
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = Table('ct', pgmetadata,
+                      Column('country', Text),
+                      Column('y1', Integer),
+                      Column('y2', Integer),
+                      Column('y3', Integer),
+                      Column('y4', Integer),
+                      )
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    assert [tuple(x) for x in pgengine.execute(q)] == [
+        ('foo', 200, 100, 550, 200)
+        ]
+
+
+def test_breaksOnSqlite(sqliteEngine):
+    meta = MetaData(bind=sqliteEngine)
+
+    raw = Table('raw', meta,
+                Column('country', Text),
+                Column('year', Integer),
+                Column('quantity', Integer),
+                Column('unrelated_field', Text))
+    data = [
+            ('India', 2009, 100, "foo"),
+            ('India', 2010, 150, "foo"),
+            ('India', 2011, 200, "foo"),
+            ('Czechoslovakia', 2008, 200, "foo"),
+            ('Czechoslovakia', 2010, 400, "foo")
+            ]
+    raw.create()
+    for line in data:
+        raw.insert().values(line).execute()
+
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.country,
+                raw.c.year,
+                raw.c.quantity]).where(raw.c.country == 'India')
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = Table('ct', meta,
+                      Column('country', Text),
+                      Column('y1', Integer),
+                      Column('y2', Integer),
+                      Column('y3', Integer),
+                      Column('y4', Integer),
+                      )
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    with pytest.raises(CompileError):
+        sqliteEngine.execute(q)
+
+    raw.drop()
+    meta.drop_all()
+
+
+def test_coreReturnBySelect(pgengine, pgmetadata, tableraw):
+    """Test the simple case of crosstabing all of the data in the table."""
+    raw = tableraw
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.country,
+                raw.c.year,
+                raw.c.quantity])
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = select([
+        raw.c.country.label('country'),
+        raw.c.quantity.label('y1'),
+        raw.c.quantity.label('y2'),
+        raw.c.quantity.label('y3'),
+        raw.c.quantity.label('y4')
+    ])
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    assert [tuple(x) for x in pgengine.execute(q)] == [
+        ('Czechoslovakia', 200, None, 400, None),
+        ('India', None, 100, 150, 200)
+        ]
+
+
+def test_coreReturnByTuple(pgengine, pgmetadata, tableraw):
+    """Test the simple case of crosstabing all of the data in the table."""
+    raw = tableraw
+    # Define the input table
+    crosstab_input = \
+    select([    raw.c.country,
+                raw.c.year,
+                raw.c.quantity])
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = \
+        select([distinct(raw.c.year)])
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = (
+        Column('country', Text),
+        Column('y1', Integer),
+        Column('y2', Integer),
+        Column('y3', Integer),
+        Column('y4', Integer)
+    )
+
+    # Finally, the crosstab query itself.
+    q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
+                                           categories=categories))
+
+    assert [tuple(x) for x in pgengine.execute(q)] == [
+        ('Czechoslovakia', 200, None, 400, None),
+        ('India', None, 100, 150, 200)
+        ]
+
+
+# --------------------- ORM Tests -------------------------------------
+@pytest.mark.usefixtures("ormCensusData")
+def test_ormReturnAll(ormCensus, pgsession):
+    """Test that you can combine crosstab with ORM Queries."""
+    # Define the input table
+    crosstab_input = pgsession.query(ormCensus.country, ormCensus.year,
+                                     ormCensus.quantity)
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = pgsession.query(ormCensus.year).group_by(ormCensus.year)
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = (
+        Column('country', Text),
+        Column('y1', Integer),
+        Column('y2', Integer),
+        Column('y3', Integer),
+        Column('y4', Integer)
+    )
+
+    # Finally, the crosstab query itself.
+    q = pgsession.query(*ret_types).select_from(
+        crosstab(crosstab_input, ret_types, categories=categories))
+
+    assert [tuple(x) for x in q.all()] == [
+        ('Czechoslovakia', 200, None, 400, None),
+        ('India', None, 100, 150, 200)
+        ]
+
+
+@pytest.mark.usefixtures("ormCensusData")
+def test_ormReturnSome(ormCensus, pgsession):
+    """Test that you can combine crosstab with ORM Queries."""
+    # Define the input table
+    crosstab_input = pgsession.query(
+        ormCensus.country,
+        ormCensus.year,
+        ormCensus.quantity
+        ).filter(ormCensus.country == 'India')
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = pgsession.query(ormCensus.year).group_by(ormCensus.year)
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = (
+        Column('country', Text),
+        Column('y1', Integer),
+        Column('y2', Integer),
+        Column('y3', Integer),
+        Column('y4', Integer)
+    )
+
+    # Finally, the crosstab query itself.
+    q = pgsession.query(*ret_types).select_from(
+        crosstab(crosstab_input, ret_types, categories=categories))
+
+    assert [tuple(x) for x in q.all()] == [
+        ('India', None, 100, 150, 200)
+        ]
+
+
+@pytest.mark.usefixtures("ormCensusData")
+def test_ormReturnSome(ormCensus, pgsession):
+    """Test that you can combine crosstab with ORM Queries."""
+    # Define the input table
+    crosstab_input = pgsession.query(
+        ormCensus.unrelated_field,
+        ormCensus.year,
+        func.sum(ormCensus.quantity)
+    ).filter(
+        ormCensus.unrelated_field == 'foo'
+    ).group_by(
+        ormCensus.unrelated_field,
+        ormCensus.year
+    )
+
+    # Define the categories. For us, this is 2008, 2009, 2010 etc.
+    categories = pgsession.query(ormCensus.year).group_by(ormCensus.year)
+
+    # Define return columns. Table is an easy way to do that.
+    ret_types = (
+        Column('country', Text),
+        Column('y1', Integer),
+        Column('y2', Integer),
+        Column('y3', Integer),
+        Column('y4', Integer)
+    )
+
+    # Finally, the crosstab query itself.
+    q = pgsession.query(*ret_types).select_from(
+        crosstab(crosstab_input, ret_types, categories=categories))
+
+    assert [tuple(x) for x in q.all()] == [
+        ('foo', 200, 100, 550, 200)
+        ]

--- a/test_crosstab.py
+++ b/test_crosstab.py
@@ -15,7 +15,7 @@ from crosstab import crosstab
 def pgengine(request):
     """Create a sqlalchemy engine for a PostgreSQL DB."""
     envFile = request.param
-    if envFile != '' and envFile is not None:
+    if os.environ.get('DBCONNECTION', None) is None:
         with open(envFile) as envVars:
             for line in envVars:
                 var, val = line.split('=', 1)

--- a/test_crosstab.py
+++ b/test_crosstab.py
@@ -387,7 +387,7 @@ def test_ormReturnSome(ormCensus, pgsession):
 
 
 @pytest.mark.usefixtures("ormCensusData")
-def test_ormReturnSome(ormCensus, pgsession):
+def test_ormReturnAggregate(ormCensus, pgsession):
     """Test that you can combine crosstab with ORM Queries."""
     # Define the input table
     crosstab_input = pgsession.query(

--- a/test_crosstab.py
+++ b/test_crosstab.py
@@ -254,7 +254,7 @@ def test_breaksOnSqlite(sqliteEngine):
     q = select(['*']).select_from(crosstab(crosstab_input, ret_types,
                                            categories=categories))
 
-    with pytest.raises(CompileError):
+    with pytest.raises(Exception):
         sqliteEngine.execute(q)
 
     raw.drop()


### PR DESCRIPTION
I needed `crosstab` support for generating graphs in a SQL Alchemy ORM project, so I thought I'd share the code.

Major changes:
- **Pytest-based tests file**. Not complete, but covers a lot of the common cases for two-argument `crosstab`.
- **Added support for selectables in general and tuples of `Column`s in the Return Def**. This allows me to use the same crosstab code multiple times in the same `Session` without having to generate a new table name. Generating a new table for each request could add up over the course of days or months in a web server (ie, memory leak). Depends on details.
- **Remove the result set name from the `AS` clause**. Generic selectables and `Query` objects don't have a name, and I couldn't find a SQLA way to generate a unique name, so I removed the return value name (in the `AS` clause) from the compilation. Works on 9.6, and works in CI, so I'm not sure why the docs consistently include a name. Being able to get a compiled name from `.alias` would be a great way to make this work, if I was smart enough to figure it out. I tried various manipulations of `Alias.name`, but there's some extra machinery going on there I don't understand.
- **Support for `Query` objects in `stmt` and `categories` arguments**. For ORM projects, that's a major source of cleaner code. Still not perfect, but I think the tests show a pretty good way to use the new code.

Less major changes:
- **Added `requirements.txt` for better dependency control**. Just makes life easier.
- **Travis CI configuration**. If you decide to enable Travis CI for pull requests against your code, I've got a config file that works. Not sure how to do multiple versions of PostgreSQL, but at least there's multiple versions of Python.
- **Support for `envfile.txt` in tests.** Because Windows doesn't really handle environment variables well, and a file ignored by git is not the worst place to stick a DB Connection String.